### PR TITLE
uninstall pip version of compose

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,18 @@
 ---
+- name: check if pip itself is installed
+  command: "pip --version"
+  ignore_errors: true
+  changed_when: false
+  check_mode: no
+  register: pip_is_installed
+
+- name: ensure pip version of compose is not installed
+  pip:
+    name: docker-compose
+    state: absent
+  when: pip_is_installed.rc == 0
+  become: yes
+
 - name: downloading docker-compose...
   become: yes
   become_user: root


### PR DESCRIPTION
I'd been using https://galaxy.ansible.com/franklinkim/docker-compose/ , which installs the pip version, but I got saddled with [pip dependency issues](https://github.com/weareinteractive/ansible-docker-compose/issues/4). After dealing with that, I realize that I don't like the idea of relying on the system python/pip.

Until we have [package repos](https://github.com/docker/compose/issues/2235), I figure the binary installation may be the least bad way to install it.

In part to help me clean up after using the other role, please consider pip package housekeeping as part of this role.